### PR TITLE
Now `I` BStruct format accept integer or datetime format Y-m-d H:i:s …

### DIFF
--- a/scripts/py/mt_modify.py
+++ b/scripts/py/mt_modify.py
@@ -4,6 +4,7 @@
 import argparse
 import datetime
 import os
+import re
 import sys
 import struct
 from copy import copy
@@ -56,7 +57,13 @@ def modify_field(ss, field_name, value):
         else:
             value = value.encode('utf-8')
     elif fmts[-1] == 'I':
-        value = int(datetime.datetime.strptime(value, '%Y-%m-%d %H:%M:%S').timestamp())
+        # That could be integer or date time which must be converted to timestamp.
+        if value.isdigit():
+            value = int(value, 0)
+        elif re.match(r"""\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}""", value):
+            value = int(datetime.datetime.strptime(value, '%Y-%m-%d %H:%M:%S').timestamp())
+        else:
+            raise InvalidArgument('Invalid value for field "{}". Valid types are: int or date time (Y-m-d H:i:s)'.format(field_name))
     elif fmts[-1] == 'd':
         value = float(value)
     elif fmts[-1] == 'i':


### PR DESCRIPTION
…which is then converted to timestamp. Fixes #161